### PR TITLE
Compatibility with crystal >= 0.34.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - TSUYUSATO Kitsune <make.just.on@gmail.com>
 
-crystal: 0.20.1
+crystal: 0.35.1
 
 license: MIT

--- a/src/serialport.cr
+++ b/src/serialport.cr
@@ -8,7 +8,7 @@ class SerialPort < IO::FileDescriptor
 
     fd = LibC.open(path.check_no_null_byte, oflag)
     if fd < 0
-      raise Errno.new("Error opening serial port '#{path}'")
+      raise IO::Error.new("Error opening serial port '#{path}'")
     end
 
     self.sync = true # no buffering


### PR DESCRIPTION
Errno was replaced with IO::Error